### PR TITLE
Ulcer function should have static scoping, and body scope should shadow enclosing ones.

### DIFF
--- a/src/environment.h
+++ b/src/environment.h
@@ -21,6 +21,7 @@ typedef struct value_s*         value_t;
 typedef struct table_pair_s*    table_pair_t;
 typedef struct table_s*         table_t;
 typedef struct local_context_s* local_context_t;
+typedef struct local_context_stack_s* local_context_stack_t;
 typedef struct package_s*       package_t;
 
 enum object_type_e {
@@ -120,6 +121,11 @@ struct local_context_s {
     list_node_t link;
 };
 
+struct local_context_stack_s {
+  list_t context_stack;
+  list_node_t link;
+};
+
 struct package_s {
     cstring_t name;
     hlist_node_t link;
@@ -128,6 +134,7 @@ struct package_s {
 struct environment_s {
     stack_t statement_stack;
     list_t  local_context_stack;
+    list_t  previous_context_frames;
     list_t  stack;
     heap_t  heap;
     table_t global_table;
@@ -143,6 +150,10 @@ table_t       environment_get_global_table(environment_t env);
 void          environment_push_local_context(environment_t env);
 void          environment_push_scope_local_context(environment_t env, object_t object);
 void          environment_pop_local_context(environment_t env);
+
+/* Push/pop local context stack to/from previous frames */
+void          environment_push_context_frame(environment_t env);
+void          environment_pop_context_frame(environment_t env);
 
 /* stack op */
 void          environment_clear_stack(environment_t env);

--- a/src/evaluator.c
+++ b/src/evaluator.c
@@ -599,6 +599,15 @@ static void __evaluator_function_call_expression__(environment_t env, value_t fu
     expression_function_t function;
     int scopecount = 0;
 
+    // old context shouldn't interfere with function body evaluation
+    environment_push_context_frame(env);
+
+    list_for_each(function_value->u.object_value->u.function->scopes, iter) {
+        object = list_element(iter, object_t, link_scope);
+        environment_push_scope_local_context(env, object);
+        scopecount++;
+    }
+
     environment_push_local_context(env);
 
     function = function_value->u.object_value->u.function->f.function_expr;
@@ -624,12 +633,6 @@ static void __evaluator_function_call_expression__(environment_t env, value_t fu
         table_push_pair(list_element(list_rbegin(env->local_context_stack), local_context_t, link)->object->u.table, env);
     }
 
-    list_for_each(function_value->u.object_value->u.function->scopes, iter) {
-        object = list_element(iter, object_t, link_scope);
-        environment_push_scope_local_context(env, object);
-        scopecount++;
-    }
-
     list_for_each(function->block, iter) {
         stmt = list_element(iter, statement_t, link);
         result = executor_statement(env, stmt);
@@ -653,6 +656,8 @@ static void __evaluator_function_call_expression__(environment_t env, value_t fu
     }
 
     environment_pop_local_context(env);
+
+    environment_pop_context_frame(env);
 }
 
 static void __evaluator_native_function_call_expression__(environment_t env, value_t function_value, list_t args)


### PR DESCRIPTION
# Problem

```
// utility function
function println(x) {
  print(x);
  print("\n");
}

function getX() {
  return x;
}

function foo() {
  return getX();
}

function bar() {
  x = 5;                     // shouldn't be in scope in `getX()` call
  return getX();
}

println(foo());              // should be `null`
println(bar());              // should be `null`


function genId() {
  x = 0;
  return function(x) { 
    return x;                // should be parameter `x`, not outer `x = 0`
  };
}

println(genId()(42));        // should be 42



function funcs() {
  f = function() { x = 42; };
  g = function() { return x; };
  return [f, g];
}

arr = funcs();
println(arr[1]());           // should be `null`
arr[0]();
println(arr[1]());           // should be `null`
```
Evaluates to
```
null
5
0
null
42
```

But we should expect (in my opinion):
```
null
null
42
null
null
```

Reason is twofold (from function call evaluation):
1. Function's enclosing scopes are pushed directly onto existing local scope stack, which means existing scopes _are available_ during evaluation of function body; that leads to dynamic scoping.
2. Function's enclosing scope is pushed onto local scope stack __after__ the function's initial body scope is pushed onto the stack; that leads to captured variables shadowing the ones in the initial scope of function body, which holds the arguments as well.

I decided to keep track of the local_contexts from previous function calls in environment, since GC needs that information.

